### PR TITLE
French translation

### DIFF
--- a/lang/english.lng
+++ b/lang/english.lng
@@ -1,7 +1,7 @@
 ##grflangid 0x01
 
 STR_GRF_NAME	:{RED}Railtype Compatibility GRF
-STR_GRF_DESC	:{GOLD}A GRF that intends to mend incompatibilities between Rail Vehicle GRFS and Track Type GRFs, so that old and new GRFs should be able to work together!{}{RED}WARNING: It is recommended to place this GRF at the end of your active GRFs list, so that it can be loaded last and not have its effects overided!{}{GOLD}Graphics drawn by and coded by {RED}UnholyPhish{GOLD}, with code borrowed from the Industrail Track Set by Erato Nysiad. Licenced under GPL v2.
+STR_GRF_DESC	:{GOLD}A GRF that intends to mend incompatibilities between Rail Vehicle GRFs and Track Type GRFs, so that old and new GRFs should be able to work together!{}{RED}WARNING: It is recommended to place this GRF at the end of your active GRFs list, so that it can be loaded last and not have its effects overided!{}{GOLD}Graphics drawn by and coded by {RED}UnholyPhish{GOLD}, with code borrowed from the Industrail Track Set by Erato Nysiad. Licenced under GPL v2.
 
 STR_RAIL_TOOLBAR			:Developer Track construction
 STR_RAIL_BUILD_NAME			:New Developer Track vehicles.

--- a/lang/french.lng
+++ b/lang/french.lng
@@ -1,4 +1,4 @@
-##grflangid 0x01
+##grflangid 0x03
 
 STR_GRF_NAME	:{RED}Railtype Compatibility GRF
 STR_GRF_DESC	:{GOLD}Un GRF qui vise à corriger les incompatibilités entre les GRFs de trains et de voies, afin que les anciens et nouvaux GRFs fonctionnent ensemble{NBSP}!{}{RED}ATTENTION{NBSP}:Il est reccomandé de placer ce GRF à la fin de la liste des GRFs actifs pour qu’il soit chargé en dernier et que ses effets ne soient pas annulés{NBSP}!{}{GOLD}Graphiques dessinés et programmés par {RED}UnholyPhish{GOLD}, avec du code emprunté à Industrial Track Set de Erato Nysiad. Sous  licence GPL v2.

--- a/lang/french.lng
+++ b/lang/french.lng
@@ -1,0 +1,19 @@
+##grflangid 0x01
+
+STR_GRF_NAME	:{RED}Railtype Compatibility GRF
+STR_GRF_DESC	:{GOLD}Un GRF qui vise à corriger les incompatibilités entre les GRFs de trains et de voies, afin que les anciens et nouvaux GRFs fonctionnent ensemble{NBSP}!{}{RED}ATTENTION{NBSP}:Il est reccomandé de placer ce GRF à la fin de la liste des GRFs actifs pour qu’il soit chargé en dernier et que ses effets ne soient pas annulés{NBSP}!{}{GOLD}Graphiques dessinés et programmés par {RED}UnholyPhish{GOLD}, avec du code emprunté à Industrial Track Set de Erato Nysiad. Sous  licence GPL v2.
+
+STR_RAIL_TOOLBAR			:Construction de voies de développement
+STR_RAIL_BUILD_NAME			:Nouveaux véhicules pour voie de développement.
+STR_RAIL_REPLACE_NAME		:Remplacer des véhicules pour voie de développement.
+STR_RAIL_NEW_TRAIN			:Voie de développement
+
+STR_SAAX_NAME				:{RED}Voie de développement
+STR_SBAX_NAME				:{RED}Voie de développement (sans ballast)
+
+
+STR_PARAM_DEBUG_TRACKS_NAME			:Voies de développement
+STR_PARAM_DEBUG_TRACKS_DESC			:Active les voies de développement, utilisées pour débugger les GRFs qui ajoutent des véhicules ferroviaires.
+
+
+

--- a/lang/french.lng
+++ b/lang/french.lng
@@ -1,7 +1,7 @@
 ##grflangid 0x03
 
 STR_GRF_NAME	:{RED}Railtype Compatibility GRF
-STR_GRF_DESC	:{GOLD}Un GRF qui vise à corriger les incompatibilités entre les GRFs de trains et de voies, afin que les anciens et nouvaux GRFs fonctionnent ensemble{NBSP}!{}{RED}ATTENTION{NBSP}:Il est reccomandé de placer ce GRF à la fin de la liste des GRFs actifs pour qu’il soit chargé en dernier et que ses effets ne soient pas annulés{NBSP}!{}{GOLD}Graphiques dessinés et programmés par {RED}UnholyPhish{GOLD}, avec du code emprunté à Industrial Track Set de Erato Nysiad. Sous  licence GPL v2.
+STR_GRF_DESC	:{GOLD}Un GRF qui vise à corriger les incompatibilités entre les GRFs de trains et de voies, afin que les anciens et nouveaux GRFs fonctionnent ensemble{NBSP}!{}{RED}ATTENTION{NBSP}:Il est recomandé de placer ce GRF à la fin de la liste des GRFs actifs pour qu’il soit chargé en dernier et que ses effets ne soient pas annulés{NBSP}!{}{GOLD}Graphiques dessinés et programmés par {RED}UnholyPhish{GOLD}, avec du code emprunté à Industrial Track Set de Erato Nysiad. Sous  licence GPL v2.
 
 STR_RAIL_TOOLBAR			:Construction de voies de développement
 STR_RAIL_BUILD_NAME			:Nouveaux véhicules pour voie de développement.


### PR DESCRIPTION
Translated the GRF into French. There is no text *directly* taken from a machine translating service, and no missing strings. The translation **should** be working as it is just a copy of `english.lng` with the string’s content and the language code changed.